### PR TITLE
[content] fix: subfolders in `Content` are not recognized on Windows

### DIFF
--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed `GitHubButton` not linking to the correct repository.
 - Renamed the `GithubLoader` route loader to `GitHubLoader`.
 - **Breaking:** Made `GitHubPageSource` private.
+- Fixed subfolders in `Content` are not recognized on Windows.
 
 ## 0.2.0
 

--- a/packages/jaspr_content/lib/src/route_loader/route_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/route_loader.dart
@@ -8,6 +8,7 @@ import 'dart:collection';
 
 import 'package:jaspr/server.dart';
 import 'package:jaspr_router/jaspr_router.dart';
+import 'package:path/path.dart' as pkg_path;
 
 import '../page.dart';
 import '../secondary_output/secondary_output.dart';
@@ -185,7 +186,7 @@ final indexRegex = RegExp(r'index\.[^/]*$');
 
 abstract class PageSource {
   PageSource(this.path, this.loader, {bool keepSuffix = false}) {
-    final segments = path.split('/');
+    final segments = pkg_path.split(path);
 
     private = segments.any((s) => s.startsWith('_') || s.startsWith('.'));
 

--- a/packages/jaspr_content/pubspec.yaml
+++ b/packages/jaspr_content/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   liquify: ^1.0.0
   markdown: ^7.3.0
   mustache_template: ^2.0.0
+  path: ^1.9.1
   syntax_highlight_lite: ^0.0.1
   universal_web: ^1.1.0
   watcher: ^1.1.1

--- a/packages/jaspr_content/test/route_loaders/filesystem_loader_test.dart
+++ b/packages/jaspr_content/test/route_loaders/filesystem_loader_test.dart
@@ -64,6 +64,30 @@ void main() {
             ]));
       });
 
+      test('loads nested file structure on windows', () async {
+        final MemoryFileSystem fs =
+            MemoryFileSystem(style: FileSystemStyle.windows);
+        // Arrange
+        final pagesDir = fs.directory('pages')..createSync();
+        pagesDir.childFile('index.md').createSync();
+        fs.directory(r'pages\blog').createSync();
+        fs.file(r'pages\blog\post-1.md').createSync();
+
+        final loader = FilesystemLoader('pages', fileSystem: fs);
+
+        // Act
+        final sources = await loader.loadPageSources();
+
+        // Assert
+        expect(sources, hasLength(2));
+        expect(
+            sources,
+            equals([
+              pageSource('index.md', '/', private: false),
+              pageSource(r'blog\post-1.md', '/blog/post-1', private: false),
+            ]));
+      });
+
       test('marks files and directories starting with an underscore as private', () async {
         // Arrange
         final pagesDir = fileSystem.directory('pages')..createSync();


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
jaspr_content doesn't recognize subfolders in the Windows path format, so a cross-platform library `path` was added to parse the format.

Using `final segments = path.replaceAll(r'\', '/').split('/');` directly is also a way to do it, but I can't evaluate which is better myself.

I'm not good at English, so please let me know if I got something wrong.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
